### PR TITLE
Add MongoDB storage

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,6 +18,18 @@ jobs:
       - name: List all files.
         run: |
           ls -al
+      - name: Create env file.
+        run: |
+          touch variables.env
+          echo FLASK_ENV=development >> variables.env
+          echo PROCESSING_API_HOST=http://interview-api.snackable.ai >> variables.env
+          echo MAX_PAGES=200 >> variables.env
+          echo DB_CONNECTION_STRING=mongodb://${{ secrets.MONGO_USERNAME }}:${{ secrets.MONGO_PASSWORD }}@db:27017/snackable?authSource=admin >> variables.env
+          echo MONGO_INITDB_DATABASE=snackable >> variables.env
+          echo MONGO_INITDB_ROOT_USERNAME=${{ secrets.MONGO_USERNAME }} >> variables.env
+          echo MONGO_INITDB_ROOT_PASSWORD=${{ secrets.MONGO_PASSWORD }} >> variables.env
+          echo MONGO_DATA_DIR=/data/db >> variables.env
+          echo MONGO_LOG_DIR=/dev/null >> variables.env
       - name: Docker build.
         run: docker-compose build api
       - name: Run flake8.

--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+variables.env
 
 # Spyder project settings
 .spyderproject

--- a/README.md
+++ b/README.md
@@ -9,21 +9,26 @@
 
 ## Summary
 
-I could only complete the very first assignment of building a single API that serves all file and segment metadata when given a “fileId” as an
-input parameter. However, I am planning to implement authentication using JWT token.
+Completed building a single API that serves all file and segment metadata when given a “fileId” as an input parameter. Furthermore, I have implemented a storage mechanism using MongoDB to store FINISHED files once fetched from APIs. Therefore, subsequent requests for same files will be served from local MongoDB rather than APIs thus reducing HTTP overhead.
 
 ## Design
+
+### Gevent
 
 Inorder to reduce the API call overhead, I have implemented the API using *gevent* asynchronous jobs. Gevent allows to spawn I/O jobs on a single thread using I/O loops and green threads. This is almost similar to how the NodeJS event loop works.
 
 Moreover, gevent applies monkey patching to most of the sync libraries so that they behave asynchronously without the need for us to tweak the code. An excellent example, is the *requests* library which makes use of the *urllib* library under the hood which when used in conjunction with gevent is monkey patched to be asynchronous.
 
-I have designed the API in 3 stages.
-1. It tries to fetch the file from paginated endpoint by looking for first 200 pages (configured as MAX_PAGES env variable) ~ 1000 records asynchronously.
-2. Once the file is fetched, I try to fetch the metadata using /api/file/details/{snackableFileId} API asynchronously.
-3. At last, I try to asynchronously fetch the segments from /api/file/segments/{snackableFileId} API.
+### API design
 
-The data captured from the 3 APIs are merged to form a single JSON object and returned to the user. For example,
+I have designed the API in below stages.
+1. Try to retrieve from local storage.
+1. If not in local storage, try to fetch the file from paginated endpoint by looking for first 200 pages (configured as MAX_PAGES env variable) ~ 1000 records asynchronously.
+2. Once the file is fetched, I try to fetch the metadata using /api/file/details/{snackableFileId} API asynchronously.
+3. Then, I try to asynchronously fetch the segments from /api/file/segments/{snackableFileId} API.
+4. Finally, the data captured from the 3 APIs are merged to form a single JSON object. This JSON is then stored in DB for posterity and returned to user.
+
+Example response,
 
 ```
 {
@@ -49,11 +54,19 @@ The data captured from the 3 APIs are merged to form a single JSON object and re
 
 In addition to that, if unable to find the file or the file is not in FINISHED status then the API raises a *404 Not Found* or *400 Bad Request* error respectively.
 
+### MongoDB
+
+Initially I thought about using Redis, but then I chose MongoDB because the composed data of a file can be a bit larger and complex. I am not sure if redis can store such data in one key-value pair. Default document size in MongoDB is 16MB.
+
+Moreover, if we plan to serve more queries in future it is better we opt for a DB rather than a key-value store.
+
+MongoDB uses WiredTiger as its storage engine which as far as I read does a pretty good job in low latency query execution.
+
 ### Dilemma
 
 Then there is the question, What can be the maximum number of records I may have to check to find a file from the paginated API? I would say the answer to this question probably is, design change!
 
-### Design change - just a thought
+### Alternative design suggestion
 
 The organic way of doing this will be for the file processing service to push a message when it completes processing a file. Then we can consume that message and store in DB for faster response to the user. This will require an async message queue system like RabbitMQ.
 
@@ -69,14 +82,30 @@ docker-compose build api
 
 ## Run the API
 
-Before running the API, please take a look at the docker-compose.yml file to make sure that you have tweaked the env variables and ports. Default values should be good, but feel free to change them as per your preference.
-
-### Environment variables
+Before running the API, please modify the DB credentials in `variables.env` file. You can create this file by copying from `sample.env` file for defaults. Credentials in sample.env are dummy and need not work.
 
 ```
-FLASK_ENV=development
+docker-compose up api
+
+curl http://localhost:9002/api/presentation/files/{snackableFileId}
 ```
-FLASK_ENV is a config used by flask framework to determine debugging level. I have not tested with other values for this variable.
+
+I am using curl as an example, you can try in browser, Postman.
+
+## Environment variables
+
+Copy the sample env file to `variables.env` file and make changes as required.
+```
+cp sample.env variables.env
+```
+Variables to look for are,
+
+```
+DB_CONNECTION_STRING=mongodb://<username>:<password>@db:27017/snackable?authSource=admin
+MONGO_INITDB_ROOT_USERNAME=<username>
+MONGO_INITDB_ROOT_PASSWORD=<password>
+```
+Change this to your preference. This is used to login to mongoDB service. Refer `docker-compose.yml` file to understand the mongo service.
 
 ```
 PROCESSING_API_HOST=http://interview-api.snackable.ai
@@ -87,16 +116,6 @@ This env variable stores the API host name to call to fetch different file detai
 MAX_PAGES=200
 ```
 Determines the maximum number of pages from the paginated API we will check before declaring file not found. 200 pages = 1000 records with 5 records per page limit.
-
-### Run
-
-```
-docker-compose up api
-
-curl http://localhost:9002/api/presentation/files/{snackableFileId}
-```
-
-I am using curl as an example, you can try in browser, Postman.
 
 ## Running tests
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,16 @@ services:
     image: snack_api:latest
     ports:
       - 9002:9001
-    environment:
-      - FLASK_ENV=development
-      - PROCESSING_API_HOST=http://interview-api.snackable.ai
-      - MAX_PAGES=200
+    env_file:
+      - variables.env
+    depends_on:
+      - db
+
+  db:
+    image: mongo:4.1.4
+    ports:
+      - 27018:27017
+    env_file:
+      - variables.env
+    volumes:
+      - /home/vol/mongo:/data/db

--- a/sample.env
+++ b/sample.env
@@ -1,0 +1,9 @@
+FLASK_ENV=development
+PROCESSING_API_HOST=http://interview-api.snackable.ai
+MAX_PAGES=200
+DB_CONNECTION_STRING=mongodb://<username>:<password>@db:27017/snackable?authSource=admin
+MONGO_INITDB_DATABASE=snackable
+MONGO_DATA_DIR=/data/db
+MONGO_LOG_DIR=/dev/null
+MONGO_INITDB_ROOT_USERNAME=<username>
+MONGO_INITDB_ROOT_PASSWORD=<password>

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -30,5 +30,6 @@ COPY api/external_api.py api/external_api.py
 COPY api/jobs.py api/jobs.py
 COPY api/app.py api/app.py
 COPY api/test api/test/
+COPY api/models.py api/models.py
 
 CMD ["gunicorn", "-k", "gevent", "-w", "2", "api.app:app", "-b 0.0.0.0:9001", "-t 300"]

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -66,10 +66,10 @@ def file_details_api(file_id):
     try:
         the_file = model.objects.get({"_id": file_id})
     except model.DoesNotExist as e:
-        LOGGER.info(f"File {file_id} not found in local storage.")
+        LOGGER.info(f"File {file_id} not found in local storage. {str(e)}.")
         pass
     else:
-        LOGGER.info(f"File found in local storage.")
+        LOGGER.info("File found in local storage.")
         return make_response(jsonify(the_file.to_son()), 200)
 
     # otherwise, fetch the file and details from processing API.

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -1,15 +1,20 @@
+import os
 import logging
 
 from flask import Flask, jsonify, make_response
+from pymodm import connect
 
 from core.logging_setup import setup_logging
 setup_logging()
 from api.decorators import log_latency_decorator
 from api.exceptions import APIException, FileInvalidStatusError, FileNotFound
 from api.jobs import GeventJobs
+from api.models import FileModel
 
 app = Flask(__name__)
 LOGGER = logging.getLogger(__name__)
+LOGGER.debug(f"Connecting to {os.environ.get('DB_CONNECTION_STRING')}.")
+connect(os.environ.get('DB_CONNECTION_STRING'))
 
 
 @app.route('/api/presentation/files/<file_id>')
@@ -22,6 +27,10 @@ def file_details_api(file_id):
 
     The API makes use of gevent as a strategy to call the 3rd party APIs
     for concurrent execution.
+
+    1. Check the file in local storage.
+    2. If not in local storage, fetch from 3rd party API.
+    3. Store the file in local storage.
 
     @return: JSON
     Success - 200 OK.
@@ -51,7 +60,20 @@ def file_details_api(file_id):
     {"error": "The message about the error."}
     """
     strategy = GeventJobs()
+    model = FileModel
 
+    # query storage for the file first.
+    try:
+        the_file = model.objects.get({"_id": file_id})
+    except model.DoesNotExist as e:
+        LOGGER.info(f"File {file_id} not found in local storage.")
+        pass
+    else:
+        LOGGER.info(f"File found in local storage.")
+        return make_response(jsonify(the_file.to_son()), 200)
+
+    # otherwise, fetch the file and details from processing API.
+    LOGGER.info(f"Fetching file {file_id} from APIs.")
     try:
         the_file = strategy.fetch_file(file_id)
     except (FileInvalidStatusError, APIException) as e:
@@ -68,4 +90,8 @@ def file_details_api(file_id):
         the_file.update({'segments': strategy.fetch_file_segments(file_id)})
     except APIException as e:
         return make_response(jsonify({'error': str(e)}), 400)
-    return make_response(jsonify(the_file), 200)
+
+    # save the fetched file details in storage for posterity.
+    LOGGER.info(f"Saving {file_id} details fetched in local storage.")
+    model(**the_file).save()
+    return make_response(jsonify(the_file), 201)

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -1,0 +1,12 @@
+from pymodm import fields, MongoModel
+
+
+class FileModel(MongoModel):
+    fileId = fields.CharField(primary_key=True, required=True)
+    processingStatus = fields.CharField(required=True)
+    fileName = fields.CharField(required=True)
+    fileLength = fields.IntegerField(required=False)
+    mp3Path = fields.URLField(required=False)
+    originalFilePath = fields.URLField(required=False)
+    seriesTitle = fields.CharField(required=False)
+    segments = fields.ListField(field=fields.DictField(), required=False)

--- a/src/api/requirements.txt
+++ b/src/api/requirements.txt
@@ -2,5 +2,6 @@ flake8==3.9.0
 Flask==1.1
 gunicorn==20.0.4
 gevent==20.12.1
+pymodm==0.4.3
 pyyaml==5.3.1
 requests==2.21.0

--- a/src/api/test/test_api.py
+++ b/src/api/test/test_api.py
@@ -1,3 +1,4 @@
+import os
 import logging
 import unittest
 from unittest.mock import patch
@@ -8,6 +9,7 @@ from api.app import app
 from api.exceptions import APIException
 
 LOGGER = logging.getLogger(__name__)
+DB_CONNECTION_STRING = os.environ.get('DB_CONNECTION_STRING')
 FILES = [
     {
         "fileId": "08448513-b980-4267-abeb-2445b4069a0c",
@@ -33,13 +35,37 @@ FILES = [
 
 FILE_DETAILS = {
     "4a551eec-7dac-46d2-8f17-b6972b864b34": {
-        "fileId": "4a551eec-7dac-46d2-8f17-b6972b864b34",
-        "originalFile": "http://example.com/abc.mp3"
+        "fileName": "1a4bae87-1eec-46de-9efb-657be6eaa8fa",
+        "fileLength": 2870700,
+        "mp3Path": "https://s3.amazonaws.com/snackable-test-audio/mp3Audio/1a4bae87-1eec-46de-9efb-657be6eaa8fa_constant_bitrate.mp3",
+        "originalFilePath": "https://s3.amazonaws.com/snackable-test-crawler-audio/1a4bae87-1eec-46de-9efb-657be6eaa8fa.mp3",
+        "seriesTitle": "Royally Obsessed"
     }
+}
+
+SEGMENTS = {
+    "4a551eec-7dac-46d2-8f17-b6972b864b34": [
+        {
+            "fileSegmentId": 1342,
+            "fileId": "4a551eec-7dac-46d2-8f17-b6972b864b34",
+            "segmentText": "Hey please rise for their majesties of royalty obsessed the podcast for all things modern. Welcome back to royalty obsessed.",
+            "startTime": 1730,
+            "endTime": 16080
+        }
+    ]
 }
 
 
 class FileDetailsAPITestCase(unittest.TestCase):
+    def setUp(self):
+        from pymodm import connect
+        from api.models import FileModel
+
+        self.model = FileModel
+        connect("mongodb://mongosnack:kcansognom@db:27017/testdb?authSource=admin")
+
+    def tearDown(self):
+        self.model.objects.all().delete()
 
     @patch('api.jobs.ProcessingAPIAdapter')
     def test_processing_file_is_bad_request(self, MockAPIClass):
@@ -102,3 +128,42 @@ class FileDetailsAPITestCase(unittest.TestCase):
         with app.test_client() as c:
             rv = c.get('/api/presentation/files/4a551eec-7dac-46d2-8f17-b6972b864b34')
             self.assertEqual(rv.status_code, 400)
+
+    @patch('api.jobs.ProcessingAPIAdapter')
+    def test_value_not_in_storage_is_fetched_from_api(self, MockAPIClass):
+        mock_instance = MockAPIClass.return_value
+        mock_instance.fetch_all.return_value = FILES
+        mock_instance.fetch_details.return_value = FILE_DETAILS['4a551eec-7dac-46d2-8f17-b6972b864b34']
+        mock_instance.fetch_segments.return_value = SEGMENTS['4a551eec-7dac-46d2-8f17-b6972b864b34']
+        with app.test_client() as c:
+            rv = c.get('/api/presentation/files/4a551eec-7dac-46d2-8f17-b6972b864b34')
+            self.assertEqual(rv.status_code, 201)
+
+    @patch('api.jobs.ProcessingAPIAdapter')
+    def test_value_in_storage_is_not_fetched_from_api(self, MockAPIClass):
+        the_file = {
+            "fileId": "4a551eec-7dac-46d2-8f17-b6972b864b34",
+            "processingStatus": "FINISHED",
+            "fileName": "1a4bae87-1eec-46de-9efb-657be6eaa8fa",
+            "fileLength": 2870700,
+            "mp3Path": "https://s3.amazonaws.com/snackable-test-audio/mp3Audio/1a4bae87-1eec-46de-9efb-657be6eaa8fa_constant_bitrate.mp3",
+            "originalFilePath": "https://s3.amazonaws.com/snackable-test-crawler-audio/1a4bae87-1eec-46de-9efb-657be6eaa8fa.mp3",
+            "seriesTitle": "Royally Obsessed",
+            "segments": [
+                {
+                    "fileSegmentId": 1342,
+                    "fileId": "4a551eec-7dac-46d2-8f17-b6972b864b34",
+                    "segmentText": "Hey please rise for their majesties of royalty obsessed the podcast for all things modern. Welcome back to royalty obsessed.",
+                    "startTime": 1730,
+                    "endTime": 16080
+                }
+            ]
+        }
+        self.model(**the_file).save()
+        mock_instance = MockAPIClass.return_value
+        mock_instance.fetch_all.return_value = FILES
+        mock_instance.fetch_details.return_value = FILE_DETAILS['4a551eec-7dac-46d2-8f17-b6972b864b34']
+        mock_instance.fetch_segments.return_value = SEGMENTS['4a551eec-7dac-46d2-8f17-b6972b864b34']
+        with app.test_client() as c:
+            rv = c.get('/api/presentation/files/4a551eec-7dac-46d2-8f17-b6972b864b34')
+            self.assertEqual(rv.status_code, 200)


### PR DESCRIPTION
This PR adds a mongo DB docker service to store FINISHED files once fetched from 3rd party APIs. Subsequent calls for the same file will fetch details from local DB and hence reduce HTTP overhead.